### PR TITLE
Create shipping status and order entries in order confirmation page

### DIFF
--- a/shipping status and order entries in order confirmation page
+++ b/shipping status and order entries in order confirmation page
@@ -1,0 +1,9 @@
+How to change the shipping status from pending to In Transit (Shipping status - In Transit)?
+
+Update the below property :
+text.account.order.unconsignedEntry.status.pending=Shipping status - In Transit
+
+This is coming from the orderUnconsignedEntries.tag file - web/webroot/WEB-INF/tags/addons/chineseaddressaddon/responsive/order/orderUnconsignedEntries.tag 
+                                  (C:\SAP-New\Hybris_New\hybris\bin\custom\yb2bacceleratorstorefront\web\webroot\WEB-INF\tags\addons\chineseaddressaddon\responsive\order\orderUnconsignedEntries.tag)
+                                  and 
+        this tag file getting called from the accountOrderDetailItems.jsp file: C:\SAP-New\Hybris_New\hybris\bin\custom\yb2bacceleratorstorefront\web\webroot\WEB-INF\views\addons\chineseaddressaddon\responsive\pages\account\accountOrderDetailItems.jsp


### PR DESCRIPTION
**Problem:**
How to change the shipping status from pending to In Transit (Shipping status - In Transit)?
<img width="944" alt="image" src="https://github.com/user-attachments/assets/87dc6062-daaf-4271-adc2-2c04e9eb18cc" />

**Solution:**
Update the below property -(\custom\yb2bacceleratorstorefront\web\webroot\WEB-INF\messages\base_en.properties)
text.account.order.unconsignedEntry.status.pending=Shipping status - In Transit

This is coming from the orderUnconsignedEntries.tag file - web/webroot/WEB-INF/tags/addons/chineseaddressaddon/responsive/order/orderUnconsignedEntries.tag 
                                  (\custom\yb2bacceleratorstorefront\web\webroot\WEB-INF\tags\addons\chineseaddressaddon\responsive\order\orderUnconsignedEntries.tag)
                                  and 
        this tag file getting called from the accountOrderDetailItems.jsp file :: \custom\yb2bacceleratorstorefront\web\webroot\WEB-INF\views\addons\chineseaddressaddon\responsive\pages\account\accountOrderDetailItems.jsp

Output:
<img width="959" alt="image" src="https://github.com/user-attachments/assets/dadc128c-7f34-4108-9394-9c931dcebc69" />

